### PR TITLE
Recalculating the fences when resizing the map

### DIFF
--- a/src/windows/map.c
+++ b/src/windows/map.c
@@ -1349,6 +1349,12 @@ static void map_window_increase_map_size()
 	map_extend_boundary_surface();
 	window_map_init_map();
 	window_map_center_on_view_point();
+    // Recalculate fences
+	for (int y = 0; y < RCT2_GLOBAL(RCT2_ADDRESS_MAP_MAX_XY, uint16); y += 32) {
+		for (int x = 0; x < RCT2_GLOBAL(RCT2_ADDRESS_MAP_MAX_XY, uint16); x += 32) {
+			update_park_fences(x, y);
+		}
+	}
 	gfx_invalidate_screen();
 }
 

--- a/src/windows/map.c
+++ b/src/windows/map.c
@@ -1349,12 +1349,6 @@ static void map_window_increase_map_size()
 	map_extend_boundary_surface();
 	window_map_init_map();
 	window_map_center_on_view_point();
-    // Recalculate fences
-	for (int y = 0; y < RCT2_GLOBAL(RCT2_ADDRESS_MAP_MAX_XY, uint16); y += 32) {
-		for (int x = 0; x < RCT2_GLOBAL(RCT2_ADDRESS_MAP_MAX_XY, uint16); x += 32) {
-			update_park_fences(x, y);
-		}
-	}
 	gfx_invalidate_screen();
 }
 

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -4191,6 +4191,8 @@ void map_extend_boundary_surface()
 		newMapElement->properties.surface.slope |= slope;
 		newMapElement->base_height = z;
 		newMapElement->clearance_height = z;
+
+		update_park_fences(x << 5, y << 5);
 	}
 
 	x = RCT2_GLOBAL(RCT2_ADDRESS_MAP_SIZE, uint16) - 2;
@@ -4225,8 +4227,9 @@ void map_extend_boundary_surface()
 		newMapElement->properties.surface.slope |= slope;
 		newMapElement->base_height = z;
 		newMapElement->clearance_height = z;
-	}
 
+		update_park_fences(x << 5, y << 5);
+	}
 }
 
 /**

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -4143,11 +4143,8 @@ void map_remove_out_of_range_elements()
 	for (int y = 0; y < (256 * 32); y += 32) {
 		for (int x = 0; x < (256 * 32); x += 32) {
 			if (x == 0 || y == 0 || x >= mapMaxXY || y >= mapMaxXY) {
+				map_buy_land_rights(x, y, x, y, 1, GAME_COMMAND_FLAG_APPLY);
 				clear_elements_at(x, y);
-			} else if (x >= mapMaxXY - 32 || y >= mapMaxXY - 32) {
-				RCT2_GLOBAL(RCT2_ADDRESS_MAP_SIZE_UNITS, uint16) += 32;
-				map_buy_land_rights(x, y, x, y, 6, GAME_COMMAND_FLAG_APPLY);
-				RCT2_GLOBAL(RCT2_ADDRESS_MAP_SIZE_UNITS, uint16) -= 32;
 			}
 		}
 	}


### PR DESCRIPTION
This PR solves the fences problem. When decreasing the map size it sets all land outside of the map to unowned, which solved the issue above, and when increasing the map size it recalculates the fences so that there is no gap near the edges where you previously owned land.
